### PR TITLE
Skip keys that are not meant to be references

### DIFF
--- a/src/spec/Reference.php
+++ b/src/spec/Reference.php
@@ -354,8 +354,9 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
                 continue;
             }
 
-            // non strings can't be references
-            if (is_string($value) === false) {
+            // only values of type string can be references
+            // and only keys indicating a reference should be parsed
+            if (! is_string($value) || ! in_array($key, ['$ref', 'externalValue'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
Hi @NickSdot

you pinged me in https://github.com/cebe/php-openapi/issues/156#issuecomment-1763659035. I know, it has been a while since then, but the urge to dive into the topic again wasn't that big, to be honest.

Once again I'm now at the good old problem that we can't update the package, so I'll give it another try. I tried your suggested performance fix, and it works 🎉. Well done!

I found this little bug, though, that `resolveRelativeUri()` is called also on values that are not meant to be URIs. I guess this was unintentionally introduced when trying to DRY the code by combining
```php
$oContextUri = $oContext->getUri();
$resolvedUri = $context->resolveRelativeUri($value);
```
before
```
if ($key === '$ref') { ... }
if ($key === 'externalValue') { ... }
```

So this PR fixes that